### PR TITLE
ci: Rename build workflow to be clearer

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Build
+name: build-and-notarize
 
 on:
   pull_request:


### PR DESCRIPTION
This updates the build workflow to explicitly include refernece to the notarization step.