### PR TITLE
ci: Run builds on macOS 13

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,8 +42,7 @@ jobs:
         APPLE_DEVELOPER_ID: ${{ secrets.APPLE_DEVELOPER_ID }}
         FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # NOTARIZE: ${{ github.ref == 'refs/heads/main' }}
-        NOTARIZE: true
+        NOTARIZE: ${{ github.ref == 'refs/heads/main' }}
         TRY_RELEASE: ${{ github.ref == 'refs/heads/main' }}
       run: scripts/build.sh
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
   test:
 
     name: Build macOS project
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
 
@@ -42,7 +42,8 @@ jobs:
         APPLE_DEVELOPER_ID: ${{ secrets.APPLE_DEVELOPER_ID }}
         FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NOTARIZE: ${{ github.ref == 'refs/heads/main' }}
+        # NOTARIZE: ${{ github.ref == 'refs/heads/main' }}
+        NOTARIZE: true
         TRY_RELEASE: ${{ github.ref == 'refs/heads/main' }}
       run: scripts/build.sh
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -154,7 +154,6 @@ codesign -dvv "$APP_PATH"
 
 # Notarize the release build.
 if $NOTARIZE ; then
-    fastlane notarize_release package:"$APP_PATH"
     # https://github.com/fastlane/fastlane/issues/19686#issuecomment-1026403378
     FL_NOTARIZE_ASC_PROVIDER="S4WXAUZQEV" fastlane notarize_release package:"$APP_PATH"
 fi


### PR DESCRIPTION
This change also includes a drive-by fix to remove an errant Fastlane notarization step that was failing due to a missing team id.